### PR TITLE
Thread generics throughout EuiBasicTable

### DIFF
--- a/src/components/basic_table/__snapshots__/custom_item_action.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/custom_item_action.test.tsx.snap
@@ -4,9 +4,11 @@ exports[`CustomItemAction render 1`] = `
 <div
   className="test"
 >
-  <Component
+  <span
     onBlur={[Function]}
     onFocus={[Function]}
-  />
+  >
+    test
+  </span>
 </div>
 `;

--- a/src/components/basic_table/action_types.ts
+++ b/src/components/basic_table/action_types.ts
@@ -1,43 +1,46 @@
+import { ReactElement } from 'react';
 import { EuiIconType } from '../icon/icon';
 import { ButtonIconColor } from '../button/button_icon/button_icon';
-import { EuiButtonEmptyColor } from '../button/button_empty/button_empty';
+import { EuiButtonEmptyColor } from '../button/button_empty';
 
-type IconFunction = (item: any) => EuiIconType;
+type IconFunction<T> = (item: T) => EuiIconType;
 type ButtonColor = ButtonIconColor | EuiButtonEmptyColor;
-type ButtonIconColorFunction = (item: any) => ButtonColor;
+type ButtonIconColorFunction<T> = (item: T) => ButtonColor;
 
-interface DefaultItemActionBase {
+interface DefaultItemActionBase<T> {
   name: string;
   description: string;
-  onClick?: (item: any) => void;
+  onClick?: (item: T) => void;
   href?: string;
   target?: string;
-  available?: (item: any) => boolean;
-  enabled?: (item: any) => boolean;
+  available?: (item: T) => boolean;
+  enabled?: (item: T) => boolean;
   isPrimary?: boolean;
   'data-test-subj'?: string;
 }
 
-export interface DefaultItemEmptyButtonAction extends DefaultItemActionBase {
+export interface DefaultItemEmptyButtonAction<T>
+  extends DefaultItemActionBase<T> {
   type?: 'button';
-  color?: EuiButtonEmptyColor | ButtonIconColorFunction;
+  color?: EuiButtonEmptyColor | ButtonIconColorFunction<T>;
 }
 
-export interface DefaultItemIconButtonAction extends DefaultItemActionBase {
+export interface DefaultItemIconButtonAction<T>
+  extends DefaultItemActionBase<T> {
   type: 'icon';
-  icon: EuiIconType | IconFunction;
-  color?: ButtonIconColor | ButtonIconColorFunction;
+  icon: EuiIconType | IconFunction<T>;
+  color?: ButtonIconColor | ButtonIconColorFunction<T>;
 }
 
-export type DefaultItemAction =
-  | DefaultItemEmptyButtonAction
-  | DefaultItemIconButtonAction;
+export type DefaultItemAction<T> =
+  | DefaultItemEmptyButtonAction<T>
+  | DefaultItemIconButtonAction<T>;
 
-export interface CustomItemAction {
-  render: (item: any, enabled?: boolean) => any;
-  available?: (item: any) => boolean;
-  enabled?: (item: any) => boolean;
+export interface CustomItemAction<T> {
+  render: (item: T, enabled?: boolean) => ReactElement;
+  available?: (item: T) => boolean;
+  enabled?: (item: T) => boolean;
   isPrimary?: boolean;
 }
 
-export type Action = DefaultItemAction | CustomItemAction;
+export type Action<T> = DefaultItemAction<T> | CustomItemAction<T>;

--- a/src/components/basic_table/basic_table.behavior.test.tsx
+++ b/src/components/basic_table/basic_table.behavior.test.tsx
@@ -2,12 +2,12 @@ import React from 'react';
 import { mount, ReactWrapper } from 'enzyme';
 import { findTestSubject } from '../../test';
 
-import { EuiBasicTable, Props } from './basic_table';
+import { EuiBasicTable, EuiBasicTableProps } from './basic_table';
 
 describe('EuiBasicTable', () => {
   describe('behavior', () => {
     describe('selected items', () => {
-      let props: Props;
+      let props: EuiBasicTableProps<{ id: string; name: string }>;
       let component: ReactWrapper;
 
       beforeEach(() => {

--- a/src/components/basic_table/basic_table.test.tsx
+++ b/src/components/basic_table/basic_table.test.tsx
@@ -10,6 +10,7 @@ import {
 } from './basic_table';
 
 import { SortDirection } from '../../services';
+import { FieldDataColumnType } from './table_types';
 
 describe('getItemId', () => {
   it('returns undefined if no itemId prop is given', () => {
@@ -123,7 +124,7 @@ describe('EuiBasicTable', () => {
             description: 'description',
           },
         ],
-        rowProps: (item: any) => {
+        rowProps: item => {
           const { id } = item;
           return {
             'data-test-subj': `row-${id}`,
@@ -178,9 +179,9 @@ describe('EuiBasicTable', () => {
             description: 'description',
           },
         ],
-        cellProps: (item: any, column: any) => {
+        cellProps: (item, column) => {
           const { id } = item;
-          const { field } = column;
+          const { field } = column as FieldDataColumnType<BasicItem>;
           return {
             'data-test-subj': `cell-${id}-${field}`,
             className: 'customRowClass',

--- a/src/components/basic_table/basic_table.test.tsx
+++ b/src/components/basic_table/basic_table.test.tsx
@@ -2,10 +2,14 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { requiredProps } from '../../test';
 
-import { FieldDataColumnType } from './table_types';
-import { EuiBasicTable, getItemId } from './basic_table';
+import {
+  EuiBasicTable,
+  EuiBasicTableColumn,
+  EuiBasicTableProps,
+  getItemId,
+} from './basic_table';
+
 import { SortDirection } from '../../services';
-import { DefaultItemAction } from './action_types';
 
 describe('getItemId', () => {
   it('returns undefined if no itemId prop is given', () => {
@@ -30,19 +34,35 @@ describe('getItemId', () => {
   });
 });
 
+interface BasicItem {
+  id: string;
+  name: string;
+}
+
+interface AgeItem extends BasicItem {
+  age: number;
+}
+
+interface CountItem {
+  id: string;
+  count: number;
+}
+
+const basicColumns: Array<EuiBasicTableColumn<BasicItem>> = [
+  {
+    field: 'name',
+    name: 'Name',
+    description: 'description',
+  },
+];
+
 describe('EuiBasicTable', () => {
   describe('empty', () => {
     test('is rendered', () => {
       const props = {
         ...requiredProps,
         items: [],
-        columns: [
-          {
-            field: 'name',
-            name: 'Name',
-            description: 'description',
-          },
-        ],
+        columns: basicColumns,
       };
       const component = shallow(<EuiBasicTable {...props} />);
 
@@ -50,7 +70,7 @@ describe('EuiBasicTable', () => {
     });
 
     test('renders a string as a custom message', () => {
-      const props = {
+      const props: EuiBasicTableProps<BasicItem> = {
         items: [],
         columns: [
           {
@@ -67,7 +87,7 @@ describe('EuiBasicTable', () => {
     });
 
     test('renders a node as a custom message', () => {
-      const props = {
+      const props: EuiBasicTableProps<BasicItem> = {
         items: [],
         columns: [
           {
@@ -90,7 +110,7 @@ describe('EuiBasicTable', () => {
 
   describe('rowProps', () => {
     test('renders rows with custom props from a callback', () => {
-      const props = {
+      const props: EuiBasicTableProps<BasicItem> = {
         items: [
           { id: '1', name: 'name1' },
           { id: '2', name: 'name2' },
@@ -112,13 +132,13 @@ describe('EuiBasicTable', () => {
           };
         },
       };
-      const component = shallow(<EuiBasicTable {...props} />);
+      const component = shallow(<EuiBasicTable<BasicItem> {...props} />);
 
       expect(component).toMatchSnapshot();
     });
 
     test('renders rows with custom props from an object', () => {
-      const props = {
+      const props: EuiBasicTableProps<BasicItem> = {
         items: [
           { id: '1', name: 'name1' },
           { id: '2', name: 'name2' },
@@ -145,7 +165,7 @@ describe('EuiBasicTable', () => {
 
   describe('cellProps', () => {
     test('renders cells with custom props from a callback', () => {
-      const props = {
+      const props: EuiBasicTableProps<BasicItem> = {
         items: [
           { id: '1', name: 'name1' },
           { id: '2', name: 'name2' },
@@ -174,7 +194,7 @@ describe('EuiBasicTable', () => {
     });
 
     test('renders rows with custom props from an object', () => {
-      const props = {
+      const props: EuiBasicTableProps<BasicItem> = {
         items: [
           { id: '1', name: 'name1' },
           { id: '2', name: 'name2' },
@@ -200,7 +220,7 @@ describe('EuiBasicTable', () => {
   });
 
   test('itemIdToExpandedRowMap renders an expanded row', () => {
-    const props = {
+    const props: EuiBasicTableProps<BasicItem> = {
       items: [
         { id: '1', name: 'name1' },
         { id: '2', name: 'name2' },
@@ -225,7 +245,7 @@ describe('EuiBasicTable', () => {
   });
 
   test('with pagination', () => {
-    const props = {
+    const props: EuiBasicTableProps<BasicItem> = {
       items: [
         { id: '1', name: 'name1' },
         { id: '2', name: 'name2' },
@@ -251,7 +271,7 @@ describe('EuiBasicTable', () => {
   });
 
   test('with pagination - 2nd page', () => {
-    const props = {
+    const props: EuiBasicTableProps<BasicItem> = {
       items: [{ id: '1', name: 'name1' }, { id: '2', name: 'name2' }],
       columns: [
         {
@@ -273,7 +293,7 @@ describe('EuiBasicTable', () => {
   });
 
   test('with pagination and error', () => {
-    const props = {
+    const props: EuiBasicTableProps<BasicItem> = {
       items: [
         { id: '1', name: 'name1' },
         { id: '2', name: 'name2' },
@@ -300,7 +320,7 @@ describe('EuiBasicTable', () => {
   });
 
   test('with pagination, hiding the per page options', () => {
-    const props = {
+    const props: EuiBasicTableProps<BasicItem> = {
       items: [
         { id: '1', name: 'name1' },
         { id: '2', name: 'name2' },
@@ -327,7 +347,7 @@ describe('EuiBasicTable', () => {
   });
 
   test('with sorting', () => {
-    const props = {
+    const props: EuiBasicTableProps<BasicItem> = {
       items: [
         { id: '1', name: 'name1' },
         { id: '2', name: 'name2' },
@@ -352,7 +372,7 @@ describe('EuiBasicTable', () => {
   });
 
   test('with sortable columns and sorting disabled', () => {
-    const props = {
+    const props: EuiBasicTableProps<BasicItem> = {
       items: [
         { id: '1', name: 'name1' },
         { id: '2', name: 'name2' },
@@ -374,7 +394,7 @@ describe('EuiBasicTable', () => {
   });
 
   test('with pagination and selection', () => {
-    const props = {
+    const props: EuiBasicTableProps<BasicItem> = {
       items: [
         { id: '1', name: 'name1' },
         { id: '2', name: 'name2' },
@@ -404,7 +424,7 @@ describe('EuiBasicTable', () => {
   });
 
   test('with pagination, selection and sorting', () => {
-    const props = {
+    const props: EuiBasicTableProps<BasicItem> = {
       items: [
         { id: '1', name: 'name1' },
         { id: '2', name: 'name2' },
@@ -439,7 +459,7 @@ describe('EuiBasicTable', () => {
 
   describe('footers', () => {
     test('do not render without a column footer definition', () => {
-      const props = {
+      const props: EuiBasicTableProps<AgeItem> = {
         items: [
           { id: '1', name: 'name1', age: 20 },
           { id: '2', name: 'name2', age: 21 },
@@ -471,7 +491,7 @@ describe('EuiBasicTable', () => {
     });
 
     test('render with pagination, selection, sorting, and footer', () => {
-      const props = {
+      const props: EuiBasicTableProps<AgeItem> = {
         items: [
           { id: '1', name: 'name1', age: 20 },
           { id: '2', name: 'name2', age: 21 },
@@ -496,13 +516,13 @@ describe('EuiBasicTable', () => {
             field: 'age',
             name: 'Age',
             description: 'your age',
-            footer: ({ items, pagination }: any) => (
+            footer: ({ items, pagination }) => (
               <strong>
                 sum:
-                {items.reduce((acc: number, cur: any) => acc + cur.age, 0)}
+                {items.reduce((acc, cur) => acc + cur.age, 0)}
                 <br />
                 total items:
-                {pagination.totalItemCount}
+                {pagination!.totalItemCount}
               </strong>
             ),
           },
@@ -527,7 +547,7 @@ describe('EuiBasicTable', () => {
   });
 
   test('with pagination, selection, sorting and column renderer', () => {
-    const props = {
+    const props: EuiBasicTableProps<BasicItem> = {
       items: [
         { id: '1', name: 'name1' },
         { id: '2', name: 'name2' },
@@ -540,7 +560,7 @@ describe('EuiBasicTable', () => {
           name: 'Name',
           description: 'description',
           sortable: true,
-          render: (name: any) => name.toUpperCase(),
+          render: (name: string) => name.toUpperCase(),
         },
       ],
       pagination: {
@@ -562,7 +582,7 @@ describe('EuiBasicTable', () => {
   });
 
   test('with pagination, selection, sorting and column dataType', () => {
-    const props = {
+    const props: EuiBasicTableProps<CountItem> = {
       items: [
         { id: '1', count: 1 },
         { id: '2', count: 2 },
@@ -577,7 +597,7 @@ describe('EuiBasicTable', () => {
           sortable: true,
           dataType: 'number',
         },
-      ] as FieldDataColumnType[],
+      ],
       pagination: {
         pageIndex: 0,
         pageSize: 3,
@@ -598,7 +618,7 @@ describe('EuiBasicTable', () => {
 
   // here we want to verify that the column renderer takes precedence over the column data type
   test('with pagination, selection, sorting, column renderer and column dataType', () => {
-    const props = {
+    const props: EuiBasicTableProps<CountItem> = {
       items: [
         { id: '1', count: 1 },
         { id: '2', count: 2 },
@@ -612,9 +632,9 @@ describe('EuiBasicTable', () => {
           description: 'description of count',
           sortable: true,
           dataType: 'number',
-          render: (count: any) => 'x'.repeat(count),
+          render: (count: number) => 'x'.repeat(count),
         },
-      ] as FieldDataColumnType[],
+      ],
       pagination: {
         pageIndex: 0,
         pageSize: 3,
@@ -634,7 +654,7 @@ describe('EuiBasicTable', () => {
   });
 
   test('with pagination, selection, sorting and a single record action', () => {
-    const props = {
+    const props: EuiBasicTableProps<BasicItem> = {
       items: [
         { id: '1', name: 'name1' },
         { id: '2', name: 'name2' },
@@ -657,7 +677,7 @@ describe('EuiBasicTable', () => {
               description: 'edit',
               onClick: () => undefined,
             },
-          ] as DefaultItemAction[],
+          ],
         },
       ],
       pagination: {
@@ -679,7 +699,7 @@ describe('EuiBasicTable', () => {
   });
 
   test('with pagination, selection, sorting and multiple record actions', () => {
-    const props = {
+    const props: EuiBasicTableProps<BasicItem> = {
       items: [
         { id: '1', name: 'name1' },
         { id: '2', name: 'name2' },
@@ -708,7 +728,7 @@ describe('EuiBasicTable', () => {
               description: 'delete',
               onClick: () => undefined,
             },
-          ] as DefaultItemAction[],
+          ],
         },
       ],
       pagination: {

--- a/src/components/basic_table/basic_table.tsx
+++ b/src/components/basic_table/basic_table.tsx
@@ -90,7 +90,9 @@ const dataTypesProfiles: DataTypeProfiles = {
 
 const DATA_TYPES = Object.keys(dataTypesProfiles);
 
-type ItemIdToExpandedRowMap = any;
+interface ItemIdToExpandedRowMap {
+  [id: string]: ReactNode;
+}
 
 export function getItemId<T>(item: T, itemId?: ItemId<T>) {
   if (itemId) {
@@ -475,7 +477,7 @@ export class EuiBasicTable<T = any> extends Component<
 
     const disabled = selectableItems.length === 0;
 
-    const onChange = (event: any) => {
+    const onChange = (event: React.ChangeEvent<HTMLInputElement>) => {
       if (event.target.checked) {
         this.changeSelection(selectableItems);
       } else {
@@ -844,7 +846,7 @@ export class EuiBasicTable<T = any> extends Component<
     const title =
       selection!.selectableMessage &&
       selection!.selectableMessage(!disabled, item);
-    const onChange = (event: any) => {
+    const onChange = (event: React.ChangeEvent<HTMLInputElement>) => {
       if (event.target.checked) {
         this.changeSelection([...this.state.selection, item]);
       } else {

--- a/src/components/basic_table/basic_table.tsx
+++ b/src/components/basic_table/basic_table.tsx
@@ -774,21 +774,18 @@ export class EuiBasicTable<T = any> extends Component<
     // Occupy full width of table, taking checkbox & mobile only columns into account.
     let expandedRowColSpan = selection ? columns.length + 1 : columns.length;
 
-    const mobileOnlyCols = columns.reduce(
-      (num: number, column: EuiBasicTableColumn<T>) => {
-        if (
-          (column as FieldDataColumnType<T>).mobileOptions &&
-          (column as FieldDataColumnType<T>).mobileOptions!.only
-        ) {
-          return num + 1;
-        }
+    const mobileOnlyCols = columns.reduce<number>((num, column) => {
+      if (
+        (column as FieldDataColumnType<T>).mobileOptions &&
+        (column as FieldDataColumnType<T>).mobileOptions!.only
+      ) {
+        return num + 1;
+      }
 
-        return (column as FieldDataColumnType<T>).isMobileHeader
-          ? num + 1
-          : num + 0; // BWC only
-      },
-      0
-    );
+      return (column as FieldDataColumnType<T>).isMobileHeader
+        ? num + 1
+        : num + 0; // BWC only
+    }, 0);
 
     expandedRowColSpan = expandedRowColSpan - mobileOnlyCols;
 

--- a/src/components/basic_table/collapsed_item_actions.test.tsx
+++ b/src/components/basic_table/collapsed_item_actions.test.tsx
@@ -20,7 +20,7 @@ describe('CollapsedItemActions', () => {
       ],
       itemId: 'id',
       item: { id: 'xyz' },
-      actionEnabled: (_: Action) => true,
+      actionEnabled: (_: Action<{ id: string }>) => true,
       onFocus: (_: FocusEvent) => {},
       onBlur: () => {},
     };

--- a/src/components/basic_table/collapsed_item_actions.tsx
+++ b/src/components/basic_table/collapsed_item_actions.tsx
@@ -11,13 +11,13 @@ import {
   DefaultItemIconButtonAction,
 } from './action_types';
 import { EuiIconType } from '../icon/icon';
-import { Item, ItemId } from './table_types';
+import { ItemId } from './table_types';
 
-interface Props {
-  actions: Action[];
-  item: Item;
-  itemId?: ItemId;
-  actionEnabled: (action: Action) => boolean;
+interface Props<T> {
+  actions: Array<Action<T>>;
+  item: T;
+  itemId?: ItemId<T>;
+  actionEnabled: (action: Action<T>) => boolean;
   className?: string;
   onFocus?: (event: FocusEvent) => void;
   onBlur?: () => void;
@@ -27,14 +27,10 @@ interface State {
   popoverOpen: boolean;
 }
 
-export class CollapsedItemActions extends Component<Props, State> {
-  private popoverDiv: HTMLDivElement | null;
+export class CollapsedItemActions<T> extends Component<Props<T>, State> {
+  private popoverDiv: HTMLDivElement | null = null;
 
-  constructor(props: Props) {
-    super(props);
-    this.state = { popoverOpen: false };
-    this.popoverDiv = null;
-  }
+  state = { popoverOpen: false };
 
   togglePopover = () => {
     this.setState(prevState => ({ popoverOpen: !prevState.popoverOpen }));
@@ -101,10 +97,11 @@ export class CollapsedItemActions extends Component<Props, State> {
         }
         const enabled = actionEnabled(action);
         allDisabled = allDisabled && !enabled;
-        if ((action as CustomItemAction).render) {
-          const customAction = action as CustomItemAction;
+        if ((action as CustomItemAction<T>).render) {
+          const customAction = action as CustomItemAction<T>;
           const actionControl = customAction.render(item, enabled);
           const actionControlOnClick =
+            // @ts-ignore
             actionControl && actionControl.props && actionControl.props.onClick;
           controls.push(
             <EuiContextMenuItem
@@ -122,12 +119,14 @@ export class CollapsedItemActions extends Component<Props, State> {
             onClick,
             name,
             'data-test-subj': dataTestSubj,
-          } = action as DefaultItemAction;
+          } = action as DefaultItemAction<T>;
           controls.push(
             <EuiContextMenuItem
               key={key}
               disabled={!enabled}
-              icon={(action as DefaultItemIconButtonAction).icon as EuiIconType}
+              icon={
+                (action as DefaultItemIconButtonAction<T>).icon as EuiIconType
+              }
               data-test-subj={dataTestSubj}
               onClick={this.onClickItem.bind(
                 null,

--- a/src/components/basic_table/custom_item_action.test.tsx
+++ b/src/components/basic_table/custom_item_action.test.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { CustomItemAction } from './custom_item_action';
+import { CustomItemAction, Props } from './custom_item_action';
 
 describe('CustomItemAction', () => {
   test('render', () => {
-    const props = {
+    const props: Props<{ id: string }> = {
       action: {
-        render: () => 'test',
+        render: () => <span>test</span>,
       },
       enabled: true,
       item: { id: 'xyz' },

--- a/src/components/basic_table/custom_item_action.tsx
+++ b/src/components/basic_table/custom_item_action.tsx
@@ -1,12 +1,12 @@
 import React, { Component, cloneElement } from 'react';
 import { CustomItemAction as Action } from './action_types';
-import { Item, ItemId } from './table_types';
+import { ItemId } from './table_types';
 
-interface Props {
-  action: Action;
+export interface Props<T> {
+  action: Action<T>;
   enabled: boolean;
-  item: Item;
-  itemId?: ItemId;
+  item: T;
+  itemId?: ItemId<T>;
   className: string;
   index?: number;
 }
@@ -15,10 +15,10 @@ interface State {
   hasFocus: boolean;
 }
 
-export class CustomItemAction extends Component<Props, State> {
+export class CustomItemAction<T> extends Component<Props<T>, State> {
   private mounted: boolean;
 
-  constructor(props: Props) {
+  constructor(props: Props<T>) {
     super(props);
     this.state = { hasFocus: false };
 

--- a/src/components/basic_table/default_item_action.test.tsx
+++ b/src/components/basic_table/default_item_action.test.tsx
@@ -6,9 +6,13 @@ import {
   DefaultItemIconButtonAction as IconButtonAction,
 } from './action_types';
 
+interface Item {
+  id: string;
+}
+
 describe('DefaultItemAction', () => {
   test('render - default button', () => {
-    const action: EmptyButtonAction = {
+    const action: EmptyButtonAction<Item> = {
       name: 'action1',
       description: 'action 1',
       onClick: () => {},
@@ -25,7 +29,7 @@ describe('DefaultItemAction', () => {
   });
 
   test('render - button', () => {
-    const action: EmptyButtonAction = {
+    const action: EmptyButtonAction<Item> = {
       name: 'action1',
       description: 'action 1',
       type: 'button',
@@ -43,7 +47,7 @@ describe('DefaultItemAction', () => {
   });
 
   test('render - icon', () => {
-    const action: IconButtonAction = {
+    const action: IconButtonAction<Item> = {
       name: 'action1',
       description: 'action 1',
       type: 'icon',

--- a/src/components/basic_table/default_item_action.tsx
+++ b/src/components/basic_table/default_item_action.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react';
+import React, { ReactElement } from 'react';
 import { isString } from '../../services/predicate';
 import { EuiButtonEmpty, EuiButtonIcon } from '../button';
 import { EuiToolTip } from '../tool_tip';
@@ -6,23 +6,26 @@ import {
   DefaultItemAction as Action,
   DefaultItemIconButtonAction as IconButtonAction,
 } from './action_types';
-import { Item, ItemId } from './table_types';
+import { ItemId } from './table_types';
 
-interface Props {
-  action: Action;
+interface Props<T> {
+  action: Action<T>;
   enabled: boolean;
-  item: Item;
-  itemId?: ItemId;
+  item: T;
+  itemId?: ItemId<T>;
   className?: string;
   index?: number;
 }
 
-export const DefaultItemAction: FunctionComponent<Props> = ({
+// In order to use generics with an arrow function inside a .tsx file, it's necessary to use
+// this `extends` hack and declare the types as shown, instead of declaring the const as a
+// FunctionComponent
+export const DefaultItemAction = <T extends {}>({
   action,
   enabled,
   item,
   className,
-}: Props) => {
+}: Props<T>): ReactElement => {
   if (!action.onClick && !action.href) {
     throw new Error(`Cannot render item action [${
       action.name
@@ -36,7 +39,7 @@ export const DefaultItemAction: FunctionComponent<Props> = ({
     isString(action.color) ? action.color : action.color(item);
   const color = action.color ? resolveActionColor(action) : 'primary';
 
-  const { icon: buttonIcon } = action as IconButtonAction;
+  const { icon: buttonIcon } = action as IconButtonAction<T>;
   const resolveActionIcon = (action: any) =>
     isString(action.icon) ? action.icon : action.icon(item);
   const icon = buttonIcon ? resolveActionIcon(action) : undefined;

--- a/src/components/basic_table/expanded_item_actions.test.tsx
+++ b/src/components/basic_table/expanded_item_actions.test.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { ExpandedItemActions } from './expanded_item_actions';
+import { ExpandedItemActions, Props } from './expanded_item_actions';
 
 describe('ExpandedItemActions', () => {
   test('render', () => {
-    const props = {
+    const props: Props<{ id: string }> = {
       actions: [
         {
           name: 'default1',

--- a/src/components/basic_table/expanded_item_actions.tsx
+++ b/src/components/basic_table/expanded_item_actions.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react';
+import React, { ReactElement, ReactNode } from 'react';
 import classNames from 'classnames';
 import { DefaultItemAction } from './default_item_action';
 import { CustomItemAction } from './custom_item_action';
@@ -7,28 +7,28 @@ import {
   CustomItemAction as CustomAction,
   DefaultItemAction as DefaultAction,
 } from './action_types';
-import { Item, ItemId } from './table_types';
+import { ItemId } from './table_types';
 
-interface Props {
-  actions: Action[];
-  itemId: ItemId;
-  item: Item;
-  actionEnabled: any;
+export interface Props<T> {
+  actions: Array<Action<T>>;
+  itemId: ItemId<T>;
+  item: T;
+  actionEnabled: (action: Action<T>) => boolean;
   className?: string;
 }
 
-export const ExpandedItemActions: FunctionComponent<Props> = ({
+export const ExpandedItemActions = <T extends {}>({
   actions,
   itemId,
   item,
   actionEnabled,
   className,
-}: Props) => {
+}: Props<T>): ReactElement => {
   const moreThanThree = actions.length > 2;
 
   return (
     <>
-      {actions.reduce<React.ReactNode[]>((tools, action, index) => {
+      {actions.reduce<ReactNode[]>((tools, action, index) => {
         const available = action.available ? action.available(item) : true;
         if (!available) {
           return tools;
@@ -42,14 +42,14 @@ export const ExpandedItemActions: FunctionComponent<Props> = ({
           expandedItemActions__completelyHide: moreThanThree && index < 2,
         });
 
-        if ((action as CustomAction).render) {
+        if ((action as CustomAction<T>).render) {
           // custom action has a render function
           tools.push(
             <CustomItemAction
               key={key}
               className={classes}
               index={index}
-              action={action as CustomAction}
+              action={action as CustomAction<T>}
               enabled={enabled}
               itemId={itemId}
               item={item}
@@ -61,7 +61,7 @@ export const ExpandedItemActions: FunctionComponent<Props> = ({
               key={key}
               className={classes}
               index={index}
-              action={action as DefaultAction}
+              action={action as DefaultAction<T>}
               enabled={enabled}
               itemId={itemId}
               item={item}

--- a/src/components/basic_table/in_memory_table.test.tsx
+++ b/src/components/basic_table/in_memory_table.test.tsx
@@ -2,13 +2,34 @@ import React from 'react';
 import { mount, shallow } from 'enzyme';
 import { requiredProps } from '../../test';
 
-import { EuiInMemoryTable, FilterConfig } from './in_memory_table';
+import {
+  EuiInMemoryTable,
+  EuiInMemoryTableProps,
+  FilterConfig,
+} from './in_memory_table';
 import { ENTER } from '../../services/key_codes';
 import { SortDirection } from '../../services';
 
+interface BasicItem {
+  id: number | string;
+  name: string;
+}
+
+interface StateItem {
+  active: boolean;
+  name: string;
+}
+
+interface ComplexItem {
+  active: boolean;
+  complex: {
+    name: string;
+  };
+}
+
 describe('EuiInMemoryTable', () => {
   test('empty array', () => {
-    const props = {
+    const props: EuiInMemoryTableProps<BasicItem> = {
       ...requiredProps,
       items: [],
       columns: [
@@ -25,7 +46,7 @@ describe('EuiInMemoryTable', () => {
   });
 
   test('with message', () => {
-    const props = {
+    const props: EuiInMemoryTableProps<BasicItem> = {
       ...requiredProps,
       items: [],
       columns: [
@@ -43,7 +64,7 @@ describe('EuiInMemoryTable', () => {
   });
 
   test('with message and loading', () => {
-    const props = {
+    const props: EuiInMemoryTableProps<BasicItem> = {
       ...requiredProps,
       items: [],
       columns: [
@@ -62,7 +83,7 @@ describe('EuiInMemoryTable', () => {
   });
 
   test('with executeQueryOptions', () => {
-    const props = {
+    const props: EuiInMemoryTableProps<BasicItem> = {
       ...requiredProps,
       items: [],
       columns: [
@@ -82,7 +103,7 @@ describe('EuiInMemoryTable', () => {
   });
 
   test('with items', () => {
-    const props = {
+    const props: EuiInMemoryTableProps<BasicItem> = {
       ...requiredProps,
       items: [
         { id: '1', name: 'name1' },
@@ -103,7 +124,7 @@ describe('EuiInMemoryTable', () => {
   });
 
   test('with items and expanded item', () => {
-    const props = {
+    const props: EuiInMemoryTableProps<BasicItem> = {
       ...requiredProps,
       items: [
         { id: '1', name: 'name1' },
@@ -128,7 +149,7 @@ describe('EuiInMemoryTable', () => {
   });
 
   test('with items and message - expecting to show the items', () => {
-    const props = {
+    const props: EuiInMemoryTableProps<BasicItem> = {
       ...requiredProps,
       message: 'show me!',
       items: [
@@ -150,7 +171,7 @@ describe('EuiInMemoryTable', () => {
   });
 
   test('with pagination', () => {
-    const props = {
+    const props: EuiInMemoryTableProps<BasicItem> = {
       ...requiredProps,
       items: [
         { id: '1', name: 'name1' },
@@ -174,7 +195,7 @@ describe('EuiInMemoryTable', () => {
   });
 
   test('with pagination and default page size and index', () => {
-    const props = {
+    const props: EuiInMemoryTableProps<BasicItem> = {
       ...requiredProps,
       items: [
         { id: '1', name: 'name1' },
@@ -200,7 +221,7 @@ describe('EuiInMemoryTable', () => {
   });
 
   test('with pagination, default page size and error', () => {
-    const props = {
+    const props: EuiInMemoryTableProps<BasicItem> = {
       ...requiredProps,
       items: [{ id: '1', name: 'name1' }],
       error: 'ouch!',
@@ -222,7 +243,7 @@ describe('EuiInMemoryTable', () => {
   });
 
   test('with pagination, hiding the per page options', () => {
-    const props = {
+    const props: EuiInMemoryTableProps<BasicItem> = {
       ...requiredProps,
       items: [
         { id: '1', name: 'name1' },
@@ -247,7 +268,7 @@ describe('EuiInMemoryTable', () => {
 
   describe('sorting', () => {
     test('with field sorting (off by default)', () => {
-      const props = {
+      const props: EuiInMemoryTableProps<BasicItem> = {
         ...requiredProps,
         items: [
           { id: '3', name: 'name3' },
@@ -274,7 +295,7 @@ describe('EuiInMemoryTable', () => {
     });
 
     test('with field sorting (on by default)', () => {
-      const props = {
+      const props: EuiInMemoryTableProps<BasicItem> = {
         ...requiredProps,
         items: [
           { id: '3', name: 'name3' },
@@ -306,7 +327,7 @@ describe('EuiInMemoryTable', () => {
     });
 
     test('with name sorting', () => {
-      const props = {
+      const props: EuiInMemoryTableProps<BasicItem> = {
         ...requiredProps,
         items: [
           { id: '3', name: 'name3' },
@@ -338,7 +359,7 @@ describe('EuiInMemoryTable', () => {
     });
 
     test('verify field sorting precedes name sorting', () => {
-      const props = {
+      const props: EuiInMemoryTableProps<BasicItem> = {
         ...requiredProps,
         items: [
           { id: '1', name: 'name3' },
@@ -377,7 +398,7 @@ describe('EuiInMemoryTable', () => {
     });
 
     test('verify an invalid sort field does not blow everything up', () => {
-      const props = {
+      const props: EuiInMemoryTableProps<BasicItem> = {
         ...requiredProps,
         items: [
           { id: '3', name: 'name3' },
@@ -415,7 +436,7 @@ describe('EuiInMemoryTable', () => {
     // copy the array to ensure the `items` prop doesn't mutate
     const itemsProp = items.slice(0);
 
-    const props = {
+    const props: EuiInMemoryTableProps<BasicItem> = {
       ...requiredProps,
       items: itemsProp,
       columns: [
@@ -440,7 +461,7 @@ describe('EuiInMemoryTable', () => {
   });
 
   test('with pagination and selection', () => {
-    const props = {
+    const props: EuiInMemoryTableProps<BasicItem> = {
       ...requiredProps,
       items: [
         { id: '1', name: 'name1' },
@@ -466,7 +487,7 @@ describe('EuiInMemoryTable', () => {
   });
 
   test('with pagination, selection and sorting', () => {
-    const props = {
+    const props: EuiInMemoryTableProps<BasicItem> = {
       ...requiredProps,
       items: [
         { id: '1', name: 'name1' },
@@ -494,7 +515,7 @@ describe('EuiInMemoryTable', () => {
   });
 
   test('with pagination, selection, sorting and column renderer', () => {
-    const props = {
+    const props: EuiInMemoryTableProps<BasicItem> = {
       ...requiredProps,
       items: [
         { id: '1', name: 'name1' },
@@ -525,7 +546,7 @@ describe('EuiInMemoryTable', () => {
   });
 
   test('with pagination, selection, sorting and a single record action', () => {
-    const props = {
+    const props: EuiInMemoryTableProps<BasicItem> = {
       ...requiredProps,
       items: [
         { id: '1', name: 'name1' },
@@ -563,7 +584,7 @@ describe('EuiInMemoryTable', () => {
   });
 
   test('with pagination, selection, sorting  and simple search', () => {
-    const props = {
+    const props: EuiInMemoryTableProps<BasicItem> = {
       ...requiredProps,
       items: [
         { id: '1', name: 'name1' },
@@ -602,7 +623,7 @@ describe('EuiInMemoryTable', () => {
   });
 
   test('with pagination, selection, sorting and configured search', () => {
-    const props = {
+    const props: EuiInMemoryTableProps<BasicItem> = {
       ...requiredProps,
       items: [
         { id: '1', name: 'name1' },
@@ -656,35 +677,34 @@ describe('EuiInMemoryTable', () => {
 
   describe('search interaction & functionality', () => {
     it('updates the results as based on the entered query', () => {
-      const items = [
-        {
-          active: true,
-          name: 'Kansas',
-        },
-        {
-          active: true,
-          name: 'North Dakota',
-        },
-        {
-          active: false,
-          name: 'Florida',
-        },
-      ];
-
-      const columns = [
-        {
-          field: 'active',
-          name: 'Is Active',
-        },
-        {
-          field: 'name',
-          name: 'Name',
-        },
-      ];
-
-      const search = {};
-
-      const props = { items, columns, search, className: 'testTable' };
+      const props: EuiInMemoryTableProps<StateItem> = {
+        items: [
+          {
+            active: true,
+            name: 'Kansas',
+          },
+          {
+            active: true,
+            name: 'North Dakota',
+          },
+          {
+            active: false,
+            name: 'Florida',
+          },
+        ],
+        columns: [
+          {
+            field: 'active',
+            name: 'Is Active',
+          },
+          {
+            field: 'name',
+            name: 'Name',
+          },
+        ],
+        search: {},
+        className: 'testTable',
+      };
 
       const component = mount(<EuiInMemoryTable {...props} />);
 
@@ -717,67 +737,89 @@ describe('EuiInMemoryTable', () => {
     });
 
     it('passes down the executeQueryOptions properly', () => {
-      const items = [
-        {
-          active: true,
-          complex: {
-            name: 'Kansas',
+      const props: EuiInMemoryTableProps<ComplexItem> = {
+        items: [
+          {
+            active: true,
+            complex: {
+              name: 'Kansas',
+            },
           },
-        },
-        {
-          active: true,
-          complex: {
-            name: 'North Dakota',
+          {
+            active: true,
+            complex: {
+              name: 'North Dakota',
+            },
           },
-        },
-        {
-          active: false,
-          complex: {
-            name: 'Florida',
+          {
+            active: false,
+            complex: {
+              name: 'Florida',
+            },
           },
-        },
-      ];
-
-      const columns = [
-        {
-          field: 'active',
-          name: 'Is Active',
-        },
-        {
-          field: 'complex.name',
-          name: 'Name',
-        },
-      ];
-
-      const search = {
-        defaultQuery: 'No',
-        executeQueryOptions: {
-          defaultFields: ['complex.name'],
-        },
+        ],
+        columns: [
+          {
+            field: 'active',
+            name: 'Is Active',
+          },
+          {
+            field: 'complex.name',
+            name: 'Name',
+          },
+        ],
+        search: { defaultQuery: 'No' },
+        className: 'testTable',
+        message: <span className="customMessage">No items found!</span>,
       };
 
-      const message = <span className="customMessage">No items found!</span>;
-
-      const noDefaultFieldsComponent = mount(
-        <EuiInMemoryTable
-          {...{
-            items,
-            columns,
-            search: { defaultQuery: 'No' },
-            className: 'testTable',
-            message,
-          }}
-        />
-      );
+      const noDefaultFieldsComponent = mount(<EuiInMemoryTable {...props} />);
       // should render with the no items found text
       expect(noDefaultFieldsComponent.find('.customMessage').length).toBe(1);
 
       // With defaultFields and a search query, we should only see one
-      const defaultFieldComponent = mount(
-        <EuiInMemoryTable
-          {...{ items, columns, search, className: 'testTable', message }}
-        />
-      );
+      const props2: EuiInMemoryTableProps<ComplexItem> = {
+        items: [
+          {
+            active: true,
+            complex: {
+              name: 'Kansas',
+            },
+          },
+          {
+            active: true,
+            complex: {
+              name: 'North Dakota',
+            },
+          },
+          {
+            active: false,
+            complex: {
+              name: 'Florida',
+            },
+          },
+        ],
+        columns: [
+          {
+            field: 'active',
+            name: 'Is Active',
+          },
+          {
+            field: 'complex.name',
+            name: 'Name',
+          },
+        ],
+        search: {
+          defaultQuery: 'No',
+          executeQueryOptions: {
+            defaultFields: ['complex.name'],
+          },
+        },
+        className: 'testTable',
+        message: <span className="customMessage">No items found!</span>,
+      };
+
+      const defaultFieldComponent = mount(<EuiInMemoryTable {...props2} />);
       expect(defaultFieldComponent.find('.testTable EuiTableRow').length).toBe(
         1
       );
@@ -786,7 +828,7 @@ describe('EuiInMemoryTable', () => {
 
   describe('custom column sorting', () => {
     it('calls the sortable function and uses its return value for sorting', () => {
-      const props = {
+      const props: EuiInMemoryTableProps<BasicItem> = {
         ...requiredProps,
         items: [
           { id: 7, name: 'Alfred' },
@@ -820,7 +862,7 @@ describe('EuiInMemoryTable', () => {
 
   describe('behavior', () => {
     test('pagination', async () => {
-      const props = {
+      const props: EuiInMemoryTableProps<BasicItem> = {
         ...requiredProps,
         items: [
           { id: '1', name: 'name1' },
@@ -854,7 +896,7 @@ describe('EuiInMemoryTable', () => {
     });
 
     test('onTableChange callback', () => {
-      const props = {
+      const props: EuiInMemoryTableProps<BasicItem> = {
         ...requiredProps,
         items: [
           { id: '1', name: 'name1' },
@@ -892,7 +934,7 @@ describe('EuiInMemoryTable', () => {
         },
       });
 
-      props.onTableChange.mockClear();
+      (props.onTableChange as jest.Mock).mockClear();
       component
         .find(
           '[data-test-subj*="tableHeaderCell_name_0"] [data-test-subj="tableHeaderSortButton"]'

--- a/src/components/basic_table/in_memory_table.tsx
+++ b/src/components/basic_table/in_memory_table.tsx
@@ -155,7 +155,9 @@ export type EuiInMemoryTableProps<T> = CommonProps & {
   executeQueryOptions?: any;
   isSelectable?: boolean;
   hasActions?: boolean;
-  itemIdToExpandedRowMap?: any;
+  itemIdToExpandedRowMap?: {
+    [id: string]: ReactNode;
+  };
 };
 
 interface State<T> {

--- a/src/components/basic_table/index.ts
+++ b/src/components/basic_table/index.ts
@@ -1,2 +1,2 @@
-export { EuiBasicTable } from './basic_table';
-export { EuiInMemoryTable } from './in_memory_table';
+export { EuiBasicTable, EuiBasicTableProps } from './basic_table';
+export { EuiInMemoryTable, EuiInMemoryTableProps } from './in_memory_table';

--- a/src/components/basic_table/loading_table_body.tsx
+++ b/src/components/basic_table/loading_table_body.tsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { EuiTableBody } from '../table/table_body';
+import { EuiTableBody } from '../table';
 
 export class LoadingTableBody extends Component<{}> {
   private cleanups: Array<() => void>;

--- a/src/components/basic_table/table_types.ts
+++ b/src/components/basic_table/table_types.ts
@@ -1,23 +1,22 @@
-import { ReactNode } from 'react';
-import { HorizontalAlignment, PropertySort } from '../../services';
+import { ReactElement, ReactNode } from 'react';
+import { Direction, HorizontalAlignment } from '../../services';
 import { Pagination } from './pagination_bar';
 import { Action } from './action_types';
 
-export type Item = any;
-export type ItemId = string | ((item: Item) => string);
+export type ItemId<T> = string | ((item: T) => string);
 export type DataType = 'auto' | 'string' | 'number' | 'boolean' | 'date';
 
-export interface FooterProps {
-  items: Item[];
+export interface FooterProps<T> {
+  items: T[];
   pagination?: Pagination;
 }
-export interface FieldDataColumnType {
-  field: string;
+export interface FieldDataColumnType<T> {
+  field: keyof T | string; // supports outer.inner key paths
   name: ReactNode;
   description?: string;
   dataType?: DataType;
   width?: string;
-  sortable?: boolean | ((item: Item) => number | string);
+  sortable?: boolean | ((item: T) => number | string);
   isExpander?: boolean;
   textOnly?: boolean;
   align?: HorizontalAlignment;
@@ -26,37 +25,40 @@ export interface FieldDataColumnType {
   mobileOptions?: {
     show?: boolean;
     only?: boolean;
-    render?: (item: Item) => ReactNode;
+    render?: (item: T) => ReactNode;
     header?: boolean;
   };
   hideForMobile?: boolean;
-  render?: (value: any, record: any) => ReactNode;
-  footer?: string | React.ReactElement | ((props: FooterProps) => ReactNode);
+  render?: (value: any, record: T) => ReactNode;
+  footer?: string | ReactElement | ((props: FooterProps<T>) => ReactNode);
 }
 
-export interface ComputedColumnType {
-  render: (record: any) => ReactNode;
+export interface ComputedColumnType<T> {
+  render: (record: T) => ReactNode;
   name?: ReactNode;
   description?: string;
-  sortable?: (item: Item) => number | string;
+  sortable?: (item: T) => number | string;
   width?: string;
   truncateText?: boolean;
 }
 
-export interface ActionsColumnType {
-  actions: Action[];
+export interface ActionsColumnType<T> {
+  actions: Array<Action<T>>;
   name?: ReactNode;
   description?: string;
   width?: string;
 }
 
-export interface SortingType {
-  sort?: PropertySort;
+export interface SortingType<T> {
+  sort?: {
+    field: keyof T;
+    direction: Direction;
+  };
   allowNeutralSort?: boolean;
 }
 
-export interface SelectionType {
-  onSelectionChange?: (selection: Item) => void;
-  selectable?: (item: Item) => boolean;
-  selectableMessage?: (selectable: boolean, item: Item) => string;
+export interface SelectionType<T> {
+  onSelectionChange?: (selection: T[]) => void;
+  selectable?: (item: T) => boolean;
+  selectableMessage?: (selectable: boolean, item: T) => string;
 }

--- a/src/components/table/mobile/table_sort_mobile.tsx
+++ b/src/components/table/mobile/table_sort_mobile.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, ReactNode } from 'react';
 import classNames from 'classnames';
 
 import { EuiButtonEmpty } from '../../button/button_empty';
@@ -7,17 +7,28 @@ import { EuiContextMenuPanel } from '../../context_menu';
 import { EuiI18n } from '../../i18n';
 import { EuiTableSortMobileItem } from './table_sort_mobile_item';
 
-interface Props {
+interface ItemProps {
+  name: ReactNode;
+  key?: string;
+  onSort?: () => void;
+  isSorted?: boolean;
+  isSortAscending?: boolean;
+}
+
+export interface EuiTableSortMobileProps {
   className?: string;
   anchorPosition?: PopoverAnchorPosition;
-  items?: any[];
+  items?: ItemProps[];
 }
 
 interface State {
   isPopoverOpen: boolean;
 }
 
-export class EuiTableSortMobile extends Component<Props, State> {
+export class EuiTableSortMobile extends Component<
+  EuiTableSortMobileProps,
+  State
+> {
   state = {
     isPopoverOpen: false,
   };


### PR DESCRIPTION
Make it possible to type-check the props of EuiBasicTable and
EuiInMemoryTable more effectively by making their props generic, and
using the generic parameter throughout the tables' types.