### PR TITLE
ts-basic-table updates

### DIFF
--- a/scripts/babel/proptypes-from-ts-props/index.js
+++ b/scripts/babel/proptypes-from-ts-props/index.js
@@ -331,21 +331,21 @@ function convertLiteralToOneOf(types, literalNode) {
 /**
  * This function resolves discriminated union types (aka tagged union, algebraic data type).
  */
-function resolveDiscriminatedUnionType(node, optional, state) {
-  const types = state.get('types');
-
-  if (node.type === 'TSLiteralType' && node.literal.type === 'StringLiteral') {
-    return types.callExpression(
-      types.memberExpression(
-        types.identifier('PropTypes'),
-        types.identifier('oneOf')
-      ),
-      [types.arrayExpression([types.stringLiteral(node.literal.value)])]
-    );
-  } else {
-    return getPropTypesForNode(node, optional, state);
-  }
-}
+// function resolveDiscriminatedUnionType(node, optional, state) {
+//   const types = state.get('types');
+//
+//   if (node.type === 'TSLiteralType' && node.literal.type === 'StringLiteral') {
+//     return types.callExpression(
+//       types.memberExpression(
+//         types.identifier('PropTypes'),
+//         types.identifier('oneOf')
+//       ),
+//       [types.arrayExpression([types.stringLiteral(node.literal.value)])]
+//     );
+//   } else {
+//     return getPropTypesForNode(node, optional, state);
+//   }
+// }
 
 /**
  * Heavy lifter to generate the proptype AST for a node. Initially called by `processComponentDeclaration`,
@@ -372,11 +372,12 @@ function getPropTypesForNode(node, optional, state) {
     // Array<Foo>
     //       ^^^ Foo
     case 'TSTypeAnnotation':
-      propType = resolveDiscriminatedUnionType(
-        node.typeAnnotation,
-        true,
-        state
-      );
+      // propType = resolveDiscriminatedUnionType(
+      //   node.typeAnnotation,
+      //   true,
+      //   state
+      // );
+      propType = getPropTypesForNode(node.typeAnnotation, true, state);
       break;
 
     // translates intersections (Foo & Bar & Baz) to a shape with the types' members (Foo, Bar, Baz) merged together

--- a/scripts/babel/proptypes-from-ts-props/index.test.js
+++ b/scripts/babel/proptypes-from-ts-props/index.test.js
@@ -224,6 +224,33 @@ FooComponent.propTypes = {
 };`);
       });
 
+      it('understands literal values as a type', () => {
+        const result = transform(
+          `
+import React from 'react';
+interface IFooProps {
+  foo: 'bar';
+  bazz?: 5;
+}
+const FooComponent: React.SFC<IFooProps> = () => {
+  return (<div>Hello World</div>);
+}`,
+          babelOptions
+        );
+
+        expect(result.code).toBe(`import React from 'react';
+import PropTypes from "prop-types";
+
+const FooComponent = () => {
+  return <div>Hello World</div>;
+};
+
+FooComponent.propTypes = {
+  foo: PropTypes.oneOf(["bar"]).isRequired,
+  bazz: PropTypes.oneOf([5])
+};`);
+      });
+
     });
 
     describe('function propTypes', () => {

--- a/src/components/basic_table/action_types.ts
+++ b/src/components/basic_table/action_types.ts
@@ -2,6 +2,7 @@ import { ReactElement } from 'react';
 import { EuiIconType } from '../icon/icon';
 import { EuiButtonIconColor } from '../button/button_icon/button_icon';
 import { EuiButtonEmptyColor } from '../button/button_empty';
+import { ExclusiveUnion } from '../common';
 
 type IconFunction<T> = (item: T) => EuiIconType;
 type ButtonColor = EuiButtonIconColor | EuiButtonEmptyColor;
@@ -32,12 +33,13 @@ export interface DefaultItemIconButtonAction<T>
   color?: EuiButtonIconColor | ButtonIconColorFunction<T>;
 }
 
-export type DefaultItemAction<T> =
-  | DefaultItemEmptyButtonAction<T>
-  | DefaultItemIconButtonAction<T>;
+export type DefaultItemAction<T> = ExclusiveUnion<
+  DefaultItemEmptyButtonAction<T>,
+  DefaultItemIconButtonAction<T>
+>;
 
 export interface CustomItemAction<T> {
-  render: (item: T, enabled?: boolean) => ReactElement;
+  render: (item: T, enabled: boolean) => ReactElement;
   available?: (item: T) => boolean;
   enabled?: (item: T) => boolean;
   isPrimary?: boolean;

--- a/src/components/basic_table/collapsed_item_actions.test.tsx
+++ b/src/components/basic_table/collapsed_item_actions.test.tsx
@@ -15,7 +15,7 @@ describe('CollapsedItemActions', () => {
         {
           name: 'custom1',
           description: 'custom 1',
-          render: () => {},
+          render: () => <div />,
         },
       ],
       itemId: 'id',

--- a/src/components/basic_table/collapsed_item_actions.tsx
+++ b/src/components/basic_table/collapsed_item_actions.tsx
@@ -7,7 +7,6 @@ import { EuiI18n } from '../i18n';
 import {
   Action,
   CustomItemAction,
-  DefaultItemAction,
   DefaultItemIconButtonAction,
 } from './action_types';
 import { EuiIconType } from '../icon/icon';
@@ -16,7 +15,7 @@ import { ItemId } from './table_types';
 export interface CollapsedItemActionsProps<T> {
   actions: Array<Action<T>>;
   item: T;
-  itemId?: ItemId<T>;
+  itemId: ItemId<T>;
   actionEnabled: (action: Action<T>) => boolean;
   className?: string;
   onFocus?: (event: FocusEvent) => void;
@@ -25,6 +24,12 @@ export interface CollapsedItemActionsProps<T> {
 
 interface State {
   popoverOpen: boolean;
+}
+
+function actionIsCustomItemAction<T extends {}>(
+  action: Action<T>
+): action is CustomItemAction<T> {
+  return action.hasOwnProperty('render');
 }
 
 export class CollapsedItemActions<T> extends Component<
@@ -100,11 +105,10 @@ export class CollapsedItemActions<T> extends Component<
         }
         const enabled = actionEnabled(action);
         allDisabled = allDisabled && !enabled;
-        if ((action as CustomItemAction<T>).render) {
+        if (actionIsCustomItemAction(action)) {
           const customAction = action as CustomItemAction<T>;
           const actionControl = customAction.render(item, enabled);
           const actionControlOnClick =
-            // @ts-ignore
             actionControl && actionControl.props && actionControl.props.onClick;
           controls.push(
             <EuiContextMenuItem
@@ -118,11 +122,7 @@ export class CollapsedItemActions<T> extends Component<
             </EuiContextMenuItem>
           );
         } else {
-          const {
-            onClick,
-            name,
-            'data-test-subj': dataTestSubj,
-          } = action as DefaultItemAction<T>;
+          const { onClick, name, 'data-test-subj': dataTestSubj } = action;
           controls.push(
             <EuiContextMenuItem
               key={key}

--- a/src/components/basic_table/custom_item_action.tsx
+++ b/src/components/basic_table/custom_item_action.tsx
@@ -1,12 +1,10 @@
 import React, { Component, cloneElement } from 'react';
 import { CustomItemAction as Action } from './action_types';
-import { ItemId } from './table_types';
 
 export interface CustomItemActionProps<T> {
   action: Action<T>;
   enabled: boolean;
   item: T;
-  itemId?: ItemId<T>;
   className: string;
   index?: number;
 }

--- a/src/components/basic_table/default_item_action.tsx
+++ b/src/components/basic_table/default_item_action.tsx
@@ -6,15 +6,12 @@ import {
   DefaultItemAction as Action,
   DefaultItemIconButtonAction as IconButtonAction,
 } from './action_types';
-import { ItemId } from './table_types';
 
 export interface DefaultItemActionProps<T> {
   action: Action<T>;
   enabled: boolean;
   item: T;
-  itemId?: ItemId<T>;
   className?: string;
-  index?: number;
 }
 
 // In order to use generics with an arrow function inside a .tsx file, it's necessary to use

--- a/src/components/basic_table/expanded_item_actions.tsx
+++ b/src/components/basic_table/expanded_item_actions.tsx
@@ -51,7 +51,6 @@ export const ExpandedItemActions = <T extends {}>({
               index={index}
               action={action as CustomAction<T>}
               enabled={enabled}
-              itemId={itemId}
               item={item}
             />
           );
@@ -60,10 +59,8 @@ export const ExpandedItemActions = <T extends {}>({
             <DefaultItemAction
               key={key}
               className={classes}
-              index={index}
               action={action as DefaultAction<T>}
               enabled={enabled}
-              itemId={itemId}
               item={item}
             />
           );


### PR DESCRIPTION
* cleans up some `any`s
* adds the remaining `search` values for `EuiInMemoryTable`
* modifies the TypeScript->proptypes change to have less impact/limit the intended surface area
* adds an `ExclusiveUnion` around the action types (see [this comment](https://github.com/elastic/eui/blob/7cc470fd70b65cb3d17bf8439b852a153d355b1b/src/components/common.ts#L55-L119) for explanation)